### PR TITLE
Find lib using FindBin so test can be run from top-level or debugger

### DIFF
--- a/t/001-basic/015-inheritance-loading-from-disk.t
+++ b/t/001-basic/015-inheritance-loading-from-disk.t
@@ -5,7 +5,8 @@ use warnings;
 
 use Test::More;
 
-use lib 't/lib';
+use FindBin;
+use lib "$FindBin::Bin/../lib";
 
 use_ok 'Level3', '... use Level3 works';
 


### PR DESCRIPTION
Hi Stevan

I was getting a couple of errors in t/001-basic/015-inheritance-loading-from-disk.t


#   Failed test 'use Level3;'
#   at 015-inheritance-loading-from-disk.t line 10.
#     Tried to use 'Level3'.
#     Error:  Can't locate Level3.pm in @INC ...

 And same for Level2 at line 12.


You had line 8:

use lib 't/lib';

which presumably works if you are in the Moxie-0.04 directory, but not if you are running it in the debugger. You did it right in 014, but left the vulnerability in 015.

use FindBin ;
use lib "$FindBin::Bin/../lib";

fixes the problem.